### PR TITLE
Added save interface

### DIFF
--- a/Save reader/Program.cs
+++ b/Save reader/Program.cs
@@ -5,26 +5,101 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Save_reader {
-    class Program {
-        private const int APP_ID= 393520;
+namespace Save_reader
+{
+  class Program
+  {
+    private const int APP_ID = 393520;
 
-        static void Main(string[] args) {
-            if(args.Length == 1) {
-                DumpFile(args[0]);
-            } else {
-                string installPath=SteamHelper.GetInstallPathForApp(APP_ID);
-                DumpFile($@"{installPath}\data\save1");
+    static void Main(string[] args)
+    {
+      if (args.Length > 0)
+      {
+        if (Path.GetExtension(args[0]) == ".txt")
+        {
+          string path = null;
+          if (args.Length > 1)
+          {
+            if (Int32.TryParse(args[1], out int slot))
+            {
+              string installPath = SteamHelper.GetInstallPathForApp(APP_ID);
+              path = $@"{installPath}\data\save{slot}";
+              Console.WriteLine($"Writing to slot {slot}");
             }
-        }
-
-        private static void DumpFile(string fileName) {
-            var fs = File.OpenRead(fileName);
-            var sf = new SaveFile(fs);
-
-            foreach(var kv in sf.entries) {
-                Console.WriteLine($"{kv.Key} {kv.Value}");
+            else
+            {
+              path = args[1];
+              Console.WriteLine($"Writing to path {path}");
             }
+          }
+          else
+          {
+            string installPath = SteamHelper.GetInstallPathForApp(APP_ID);
+            path = $@"{installPath}\data\save1";
+            Console.WriteLine($"Writing to slot 1");
+          }
+          WriteFile(args[0], path);
         }
+        else
+        {
+          if (Int32.TryParse(args[0], out int slot))
+          {
+            string installPath = SteamHelper.GetInstallPathForApp(APP_ID);
+            DumpFile($@"{installPath}\data\save{slot}");
+          }
+          else
+          {
+            DumpFile(args[0]);
+          }
+        }
+      }
+      else
+      {
+        string installPath = SteamHelper.GetInstallPathForApp(APP_ID);
+        DumpFile($@"{installPath}\data\save1");
+      }
     }
+
+    private static void DumpFile(string fileName)
+    {
+      var fs = File.OpenRead(fileName);
+      var sf = new SaveFile(fs);
+
+      foreach (var kv in sf.entries)
+      {
+        Console.Write(kv.Key);
+        if (kv.Value is double) Console.Write(" double ");
+        else if (kv.Value is string) Console.Write(" string ");
+        else Console.Write(" unknown ");
+        Console.WriteLine(kv.Value);
+      }
+    }
+
+    private static void WriteFile(string fileName, string outputPath)
+    {
+      FileStream output = File.OpenWrite(outputPath);
+      SaveFile sf = new SaveFile();
+
+      char[] delim = new char[]{ ' ' };
+
+      foreach (string line in File.ReadLines(fileName))
+      {
+        string[] data = line.Split(delim , 3);
+        switch (data[1])
+        {
+          case "double":
+            sf.entries.Add(data[0], Double.Parse(data[2]));
+            break;
+          case "string":
+            sf.entries.Add(data[0], data[2]);
+            break;
+          default:
+            Console.WriteLine($"Can't write unknown type \"{data[1]}\" for field \"{data[0]}\"");
+            break;
+        }
+      }
+      sf.Write(output);
+    }
+
+  }
 }

--- a/Save reader/SaveFile.cs
+++ b/Save reader/SaveFile.cs
@@ -5,65 +5,90 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Save_reader {
-    class SaveFile {
+namespace Save_reader
+{
+  class SaveFile
+  {
 
-        public Dictionary<string, dynamic> entries;
+    public Dictionary<string, dynamic> entries;
 
-        private static readonly byte[] SIG = new byte[] { 0x4D, 0x41, 0x50, 0x31, 0x2E, 0x30 };
+    private static readonly byte[] SIG = new byte[] { 0x4D, 0x41, 0x50, 0x31, 0x2E, 0x30 };
 
 
-        public SaveFile(Stream s) {
-            Read(s);
-        }
-
-        public void Read(Stream s) {
-            entries = new Dictionary<string, dynamic>();
-            using(BinaryReader r = new BinaryReader(s)) {
-                var sig = r.ReadBytes(SIG.Length);
-                if(!sig.SequenceEqual(SIG)) {
-                    throw new ArgumentException("Bad signature!");
-                }
-
-                uint entryCount = r.ReadUInt32();
-                for(uint entryIndex = 0; entryIndex < entryCount; ++entryIndex) {
-                    int keyLen = r.ReadInt32();
-                    string key = r.ReadUTFString(keyLen);
-                    uint type = r.ReadUInt32();
-                    switch(type) {
-                        case 1: {
-                                var val =r.ReadDouble();
-                                entries.Add(key, val);
-                            } break;
-                        case 2: {
-                                int valLen = r.ReadInt32();
-                                string val = r.ReadUTFString(valLen);
-                                entries.Add(key, val);
-                        } break;
-                        default:
-                            throw new NotImplementedException();
-                    }
-                }
-            }
-        }
-
-        public void Write(Stream s) {
-            using(BinaryWriter w=new BinaryWriter(s)) {
-                w.Write(SIG);
-                w.Write((int)entries.Count);
-                foreach(var kv in entries) {
-                    w.WriteLenPrefixedUTFString(kv.Key);
-                    if(kv.Value is double) {
-                        w.Write((int)1);
-                        w.Write((double)kv.Value);
-                    } else if(kv.Value is string) {
-                        w.Write((int)2);
-                        w.WriteLenPrefixedUTFString((string)kv.Value);
-                    } else {
-                        throw new NotImplementedException();
-                    }
-                }
-            }
-        }
+    public SaveFile(Stream s)
+    {
+      Read(s);
     }
+
+    public SaveFile()
+    {
+      entries = new Dictionary<string, dynamic>();
+    }
+
+    public void Read(Stream s)
+    {
+      entries = new Dictionary<string, dynamic>();
+      using (BinaryReader r = new BinaryReader(s))
+      {
+        var sig = r.ReadBytes(SIG.Length);
+        if (!sig.SequenceEqual(SIG))
+        {
+          throw new ArgumentException("Bad signature!");
+        }
+
+        uint entryCount = r.ReadUInt32();
+        for (uint entryIndex = 0; entryIndex < entryCount; ++entryIndex)
+        {
+          int keyLen = r.ReadInt32();
+          string key = r.ReadUTFString(keyLen);
+          uint type = r.ReadUInt32();
+          switch (type)
+          {
+            case 1:
+              {
+                var val = r.ReadDouble();
+                entries.Add(key, val);
+              }
+              break;
+            case 2:
+              {
+                int valLen = r.ReadInt32();
+                string val = r.ReadUTFString(valLen);
+                entries.Add(key, val);
+              }
+              break;
+            default:
+              throw new NotImplementedException();
+          }
+        }
+      }
+    }
+
+    public void Write(Stream s)
+    {
+      using (BinaryWriter w = new BinaryWriter(s))
+      {
+        w.Write(SIG);
+        w.Write((int)entries.Count);
+        foreach (var kv in entries)
+        {
+          w.WriteLenPrefixedUTFString(kv.Key);
+          if (kv.Value is double)
+          {
+            w.Write((int)1);
+            w.Write((double)kv.Value);
+          }
+          else if (kv.Value is string)
+          {
+            w.Write((int)2);
+            w.WriteLenPrefixedUTFString((string)kv.Value);
+          }
+          else
+          {
+            throw new NotImplementedException();
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Changed CLI to this format
* `reader.exe [slot or path]` to read from slot or file path. If not given defaults to slot1.
* `reader.exe <file with txt extension> [slot or path]` to write dump txt file to save slot or file path. If not given saves to slot1.
As Visual Studio cannot adapt to project code style, edited files now use different format, and fixing it is a pain.